### PR TITLE
No Keyspace drop between Tests

### DIFF
--- a/hCassandra_runtests.ipynb
+++ b/hCassandra_runtests.ipynb
@@ -1,0 +1,834 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# hCassandra runTests\n",
+    "\n",
+    "## Description\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### Objective\n",
+    "\n",
+    "   This test aims to **automate**:\n",
+    "   \n",
+    "   (1) The execution of the Hydra Cassandra Stress Test (hCassandra) for increasing client load.\n",
+    "   \n",
+    "   (2) The generation of performance results presented in the form of tables and graphs for relevant metrics. \n",
+    "   \n",
+    "   To this end, performance of the Cassandra Cluster is measured as the number of clients writing and reading into the DataBase is increased. The number of clients can be defined by the user. \n",
+    "   \n",
+    " \n",
+    "### Customize the Test\n",
+    "\n",
+    "   Modify **total_num_clients** to change the sets of clients for which you wish to execute the test.\n",
+    "   \n",
+    "   Current tests have been run for a maximum of **10000** clients and a duration of 5 minutes against a 3-node Cluster (for further details on Software & Hardware specs please refer to the *Software & Hardware Specs* section).\n",
+    "   \n",
+    "### Useful HINTS for running the test\n",
+    "\n",
+    "- If test has been previously executed and output is still shown, you can restart (delete former results) by selecting in the top menu Cell -> All Output -> Clear\n",
+    "- To run test, step on top of the code cells and press the 'run cell' button on the top menu. For automatic Run select from the top menu Cell -> Run All\n",
+    "- If you wish to store your results. After RUN is finished, generate your own report by selecting FILE -> Download as -> Markdown (.md) (or any other preferred format)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Software & Hardware Specs\n",
+    "\n",
+    "---\n",
+    "\n",
+    "The tests were executed on Google Cloud Servers, with the following specs:\n",
+    "\n",
+    "#### Cassandra Cluster\n",
+    "\n",
+    "- 3 Node Cluster, each with the following specs:\n",
+    "   - 16 vCPUs\n",
+    "   - RAM: 60 GB\n",
+    "   - Disk: 60 GB\n",
+    "   - OS: Debian 3.16.7-ckt25-2\n",
+    "  \n",
+    "- Cassandra + Cassandra-Tools Version: 3.0.6\n",
+    "\n",
+    "#### Hydra Cluster\n",
+    "\n",
+    "- **MASTER**: 1 Server\n",
+    "   - 4 vCPUs\n",
+    "   - RAM: 15 GB\n",
+    "   - OS: Ubuntu 14.04\n",
+    "\n",
+    "- **SLAVES**: 9 Servers (hosts to the cassandra-stress tool)\n",
+    "   - 16 vCPUs \n",
+    "   - RAM: 60 GB\n",
+    "   - Disk: 60 GB\n",
+    "   - OS: Debian 3.16.7-ckt25-2\n",
+    "   \n",
+    "### Important \n",
+    "\n",
+    "- For the performance tests maximum file open limit (ulimit) had to be increased for the Master Node."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## hCassandra Test 1: Fixed Number of Stress Clients (Debug Mode) \n",
+    "\n",
+    "---\n",
+    "\n",
+    "The following test runs a SINGLE execution of the Cassandra Test for a fixed number of clients (total_client_count) and operations (total_ops_count). Runs in debug mode: showing logger info during execution. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "!python ./src/hCassandra_test.py --cluster_ips='10.10.1.108,10.10.1.165,10.10.1.162' --total_client_count=20 --total_ops_count=1000 --test_duration=5 "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## hCassandra Test 2: Increasing the Number of stress clients (multiple runs)\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "**IMPORTANT**:\n",
+    "\n",
+    "   If you want to change the number of clients and/or number of operations for your test, please set values to desired in the following section:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Define num Client(s) / Operation(s)\n",
+    "# total_num_clients = [10, 100, 200, 400, 800, 1600, 3200, 5000, 6000, 7000, 8000]\n",
+    "# duration_array = [5, 10, 10, 10, 10, 10, 30, 30, 60, 60, 60]\n",
+    "total_num_clients = [1600, 5000]\n",
+    "duration_array = [20, 60]\n",
+    "total_ops_count = [1000000]\n",
+    "simulate_failure = False\n",
+    "# Set IPs of Nodes in Cassandra Cluster\n",
+    "cassandra_cluster_ips = '10.10.1.108,10.10.1.165,10.10.1.162'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**UTIL FUNCTIONS**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import ast\n",
+    "\n",
+    "def get_result(test_stdout):\n",
+    "    \"\"\"This Function gets (filters) the Cassandra Test Results from stdout\"\"\"\n",
+    "    index_start = test_stdout.find('Cassandra Stress Results: \\n')\n",
+    "    index_end = test_stdout.find('Calling Server shutdown')\n",
+    "    if index_start != -1:\n",
+    "        results = test_stdout[(index_start + len('Cassandra Stress Results: \\n')):index_end]\n",
+    "        res_dict = ast.literal_eval(results)\n",
+    "        return res_dict\n",
+    "    else:\n",
+    "        return {}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following block of code is the actual **EXECUTION OF THE CASSANDRA SCALE TESTS**. This may take a couple of minutes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "STARTING CASSANDRA STRESS TESTS \n",
+      "\n",
+      "Test (1/2) in progress.. Please wait until test is completed..\n",
+      "Test SUCCESFULLY completed... \n",
+      "\n",
+      "Test (2/2) in progress.. Please wait until test is completed..\n",
+      "Test SUCCESFULLY completed... \n",
+      "\n",
+      "END OF TESTS:\n",
+      "ALL TESTS HAVE BEEN COMPLETED. PLEASE PROCEED TO GENERATE GRAPHS & TABLES WITH PERFORMANCE RESULTS.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import subprocess\n",
+    "import os\n",
+    "import json\n",
+    "import signal\n",
+    "\n",
+    "hCassandra_results = dict()\n",
+    "\n",
+    "print 'STARTING CASSANDRA STRESS TESTS \\n'\n",
+    "# Execute hCassandra_test for given client_count\n",
+    "for idx1, clients in enumerate(total_num_clients):\n",
+    "    for idx2, ops in enumerate(total_ops_count):\n",
+    "        print ('Test (%s/%s) in progress.. Please wait until test is completed..' % ((len(total_ops_count) * idx1) + idx2 + 1,len(total_num_clients) * len(total_ops_count)))\n",
+    "        # Execute hCassandra_test.py (python script for hCassandra Scale Test)\n",
+    "        if simulate_failure:\n",
+    "            hcass_cmd = \"python ./src/hCassandra_test.py --cluster_ips=%s --total_client_count=%s --total_ops_count=%s --test_duration=%s\" % (cassandra_cluster_ips, clients, ops, duration_array[idx1])\n",
+    "        else:\n",
+    "            hcass_cmd = \"python ./src/hCassandra_test.py --cluster_ips=%s --total_client_count=%s --total_ops_count=%s --test_duration=%s\" % (cassandra_cluster_ips, clients, ops, duration_array[idx1])\n",
+    "        stress_test = subprocess.Popen(hcass_cmd, stdout=subprocess.PIPE,\n",
+    "                                          stderr=subprocess.PIPE, shell=True, preexec_fn=os.setsid)\n",
+    "        stdout, stderr = stress_test.communicate()\n",
+    "        results_dict = get_result(stdout)\n",
+    "        if len(results_dict) <= 1:\n",
+    "            print ('There was an ERROR while attempting to parse stdout...')\n",
+    "            print 'STDOUT: %s' % stdout\n",
+    "            print 'STDERR: %s' % stderr\n",
+    "        if not str(clients) in hCassandra_results:\n",
+    "            hCassandra_results[str(clients)] = dict()\n",
+    "        hCassandra_results[str(clients)][str(ops)] = results_dict\n",
+    "        with open('results_hcassandra.txt', 'w') as outfile:\n",
+    "            json.dump(hCassandra_results, outfile)\n",
+    "        print 'Test SUCCESFULLY completed... \\n'\n",
+    "\n",
+    "print 'END OF TESTS:'\n",
+    "print 'ALL TESTS HAVE BEEN COMPLETED. PLEASE PROCEED TO GENERATE GRAPHS & TABLES WITH PERFORMANCE RESULTS.'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "  **NOTE:**\n",
+    "  \n",
+    "  ---\n",
+    "   \n",
+    "   Wait until RESULTS (**hCassandra_results**) are generated for all cases, and then execute the following blocks to generate:\n",
+    "   (1) Tables with results (markdown compatible) and \n",
+    "   (2) Graphs.\n",
+    "   \n",
+    "   The **END OF TEST** is indicated by a message. Please wait...\n",
+    "   \n",
+    "   ---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### RESULT PROCESSING & TABLE/ GRAPH GENERATION\n",
+    "\n",
+    "---\n",
+    "\n",
+    "In this section, we process the results for generating tables with performance values and graphs that reflect number of operations per second and median latency for increased number of clients. \n",
+    "\n",
+    "**NOTE**\n",
+    "If you are interested in representing any other performance metric, follow the pattern followed for any of the two graps already provided. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Persist results to *results_hcassandra.txt* file. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "with open('results_hcassandra.txt', 'w') as outfile:\n",
+    "    json.dump(hCassandra_results, outfile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following object converts a list to an HTML formatted table. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "class ListTable(list):\n",
+    "    \"\"\" Overridden list class which takes a 2-dimensional list of \n",
+    "        the form [[1,2,3],[4,5,6]], and renders an HTML Table in \n",
+    "        IPython Notebook. \"\"\"\n",
+    "    \n",
+    "    def _repr_html_(self):\n",
+    "        html = [\"<table>\"]\n",
+    "        for row in self:\n",
+    "            html.append(\"<tr>\")\n",
+    "            \n",
+    "            for col in row:\n",
+    "                html.append(\"<td>{0}</td>\".format(col))\n",
+    "            \n",
+    "            html.append(\"</tr>\")\n",
+    "        html.append(\"</table>\")\n",
+    "        return ''.join(html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Process and format results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy\n",
+    "\n",
+    "results_per_ops = dict()\n",
+    "\n",
+    "# Table Format: Metrics\n",
+    "header = [\n",
+    "            '# Clients',\n",
+    "            'total_ops',\n",
+    "            'op/s',\n",
+    "            'med',\n",
+    "            '.95',\n",
+    "            '.99',\n",
+    "            'max',\n",
+    "            'op_time'\n",
+    "        ]\n",
+    "\n",
+    "data_matrix_write = ListTable()\n",
+    "data_matrix_read = ListTable()\n",
+    "\n",
+    "data_matrix_write.append(header)\n",
+    "data_matrix_read.append(header)\n",
+    "\n",
+    "results_per_ops[str(total_ops_count[0])] = dict()\n",
+    "for idx1, clients in enumerate(total_num_clients):\n",
+    "    if str(clients) in hCassandra_results:\n",
+    "        res_dict = ast.literal_eval(hCassandra_results[str(clients)][str(total_ops_count[0])])\n",
+    "        if (('op/s' in res_dict['write']) and ('op/s' in res_dict['read'])): \n",
+    "            if ((len(res_dict['write']['op/s']) !=0) and (len(res_dict['read']['op/s']) !=0)):\n",
+    "                results_per_ops[str(total_ops_count[0])][str(clients)] = res_dict\n",
+    "                data_matrix_write.append([clients, sum((ops for ops in res_dict['write']['total ops'])), sum((ops for ops in res_dict['write']['op/s'])), numpy.median(res_dict['write']['med']), numpy.percentile(res_dict['write']['.95'], 95), numpy.percentile(res_dict['write']['.99'], 99), max(res_dict['write']['max']), res_dict['write']['op_time'][0]])\n",
+    "                data_matrix_read.append([clients, sum((ops for ops in res_dict['read']['total ops'])), sum((ops for ops in res_dict['read']['op/s'])), numpy.median(res_dict['read']['med']), numpy.percentile(res_dict['read']['.95'], 95), numpy.percentile(res_dict['read']['.99'], 99), max(res_dict['read']['max']), duration_array[idx1]])   \n",
+    "            else:\n",
+    "                if (len(res_dict['write']['op/s']) !=0):\n",
+    "                    data_matrix_write.append([clients, sum((ops for ops in res_dict['write']['total ops'])), sum((ops for ops in res_dict['write']['op/s'])), numpy.median(res_dict['write']['med']), numpy.percentile(res_dict['write']['.95'], 95), numpy.percentile(res_dict['write']['.99'], 99), max(res_dict['write']['max']), res_dict['write']['op_time'][0]])\n",
+    "                elif (len(res_dict['read']['op/s']) !=0):\n",
+    "                    data_matrix_read.append([clients, sum((ops for ops in res_dict['read']['total ops'])), sum((ops for ops in res_dict['read']['op/s'])), numpy.median(res_dict['read']['med']), numpy.percentile(res_dict['read']['.95'], 95), numpy.percentile(res_dict['read']['.99'], 99), max(res_dict['read']['max']), duration_array[idx1]])   \n",
+    "                else:\n",
+    "                    print (\"Removing Results for client count %s. No results found.\" % clients)\n",
+    "        else:\n",
+    "            print (\"Removing Results for client count %s. No results found.\" % clients)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Result Generation: Table\n",
+    "\n",
+    "Next, results are displayed in a Table, following the markdown format. \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save results for 'WRITE' operation in a file. This will be a backup of test results in case of failure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "text_file = open(\"write_stats_\" + str(datetime.now().strftime(\"%m%d%Y_%H%M%S\")) + \".txt\", \"w\")\n",
+    "text_file.write(\"%s\" % data_matrix_write)\n",
+    "text_file.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next table represents the results for the **WRITE** Operations:\n",
+    "\n",
+    "---\n",
+    "\n",
+    "*Table 1. \"Cassandra Performance over WRITE Operation.\"*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><td># Clients</td><td>total_ops</td><td>op/s</td><td>med</td><td>.95</td><td>.99</td><td>max</td><td>op_time</td></tr><tr><td>1600</td><td>95463784</td><td>79547</td><td>13.3</td><td>46.8</td><td>83.321</td><td>12199.8</td><td>00:20:00</td></tr><tr><td>5000</td><td>247539497</td><td>68755</td><td>45.6</td><td>164.4</td><td>244.248</td><td>18560.7</td><td>01:00:00</td></tr></table>"
+      ],
+      "text/plain": [
+       "[['# Clients', 'total_ops', 'op/s', 'med', '.95', '.99', 'max', 'op_time'],\n",
+       " [1600,\n",
+       "  95463784,\n",
+       "  79547,\n",
+       "  13.300000000000001,\n",
+       "  46.799999999999997,\n",
+       "  83.320999999999998,\n",
+       "  12199.8,\n",
+       "  '00:20:00'],\n",
+       " [5000,\n",
+       "  247539497,\n",
+       "  68755,\n",
+       "  45.600000000000001,\n",
+       "  164.40000000000001,\n",
+       "  244.24799999999999,\n",
+       "  18560.7,\n",
+       "  '01:00:00']]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_matrix_write"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next table represents the results for the **READ** Operations:\n",
+    "\n",
+    "---\n",
+    "\n",
+    "*Table 2. \"Cassandra Performance over READ Operation.\"*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": true,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "text_file = open(\"read_stats_\" + str(datetime.now().strftime(\"%m%d%Y_%H%M%S\")) + \".txt\", \"w\")\n",
+    "text_file.write(\"%s\" % data_matrix_read)\n",
+    "text_file.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><td># Clients</td><td>total_ops</td><td>op/s</td><td>med</td><td>.95</td><td>.99</td><td>max</td><td>op_time</td></tr><tr><td>1600</td><td>171777040</td><td>143142</td><td>5.3</td><td>33.51</td><td>67.678</td><td>583.5</td><td>20</td></tr><tr><td>5000</td><td>436729153</td><td>121306</td><td>21.7</td><td>111.04</td><td>193.586</td><td>832.3</td><td>60</td></tr></table>"
+      ],
+      "text/plain": [
+       "[['# Clients', 'total_ops', 'op/s', 'med', '.95', '.99', 'max', 'op_time'],\n",
+       " [1600,\n",
+       "  171777040,\n",
+       "  143142,\n",
+       "  5.2999999999999998,\n",
+       "  33.509999999999998,\n",
+       "  67.677999999999983,\n",
+       "  583.5,\n",
+       "  20],\n",
+       " [5000,\n",
+       "  436729153,\n",
+       "  121306,\n",
+       "  21.699999999999999,\n",
+       "  111.03999999999999,\n",
+       "  193.58599999999998,\n",
+       "  832.3,\n",
+       "  60]]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_matrix_read"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Result Generation: Graphs\n",
+    "\n",
+    "Next, results are displayed in Graphs. \n",
+    "\n",
+    "--- \n",
+    "\n",
+    "**IMPORTANT**\n",
+    "\n",
+    "Please, MODIFY the graphs name here if desired. Otherwise, graphs are indexed by datetime. \n",
+    "\n",
+    "\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "ops_second_graph_filename = \"hCassandra_ops_\" + str(datetime.now().strftime(\"%m%d%Y_%H%M%S\"))\n",
+    "median_latency_graph_filename = \"hCassandra_med_\" + str(datetime.now().strftime(\"%m%d%Y_%H%M%S\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "def asint(s):\n",
+    "    try: return int(s), ''\n",
+    "    except ValueError: return sys.maxint, s"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "\n",
+    "import plotly.plotly as py\n",
+    "import plotly.offline as offline\n",
+    "from plotly.graph_objs import *\n",
+    "import operator\n",
+    "import numpy\n",
+    "import collections\n",
+    "\n",
+    "# run at the start of every ipython notebook to use plotly.offline\n",
+    "offline.init_notebook_mode(connected=True)\n",
+    "\n",
+    "data_matrix = [['# ops', '# Clients', 'total_ops', 'op/s', 'pk/s', 'med', '.95', '.99', 'max', 'max_ms', 'sdv_ms', 'op_time']]\n",
+    "\n",
+    "traces_plot1 = []\n",
+    "traces_plot2 = []\n",
+    "\n",
+    "# For each trace = client count\n",
+    "for ops_count, tests_per_trace in results_per_ops.iteritems():\n",
+    "    \n",
+    "    total_ops = []\n",
+    "    op_s = []\n",
+    "    op_s_r = []\n",
+    "    med = []\n",
+    "    med_r = []\n",
+    "    p99 = []\n",
+    "    p99_r = []\n",
+    "    max_lat = []\n",
+    "    max_lat_r = []\n",
+    "    \n",
+    "    clients = []\n",
+    "    # Sort list by # Clients\n",
+    "    sortedlist = [(k, tests_per_trace[k]) for k in sorted(tests_per_trace, key=asint)]\n",
+    "    \n",
+    "    for test in sortedlist:\n",
+    "        clients.append(test[0])\n",
+    "        op_s.append(sum((ops for ops in test[1]['write']['op/s'])))\n",
+    "        med.append(numpy.median(test[1]['write']['med']))\n",
+    "        op_s_r.append(sum((ops for ops in test[1]['read']['op/s'])))\n",
+    "        med_r.append(numpy.median(test[1]['read']['med']))\n",
+    "        p99.append(numpy.percentile(test[1]['write']['.99'], 99))\n",
+    "        p99_r.append(numpy.percentile(test[1]['read']['.99'], 99))\n",
+    "        max_lat.append(max(test[1]['write']['max']))\n",
+    "        max_lat_r.append(max(test[1]['read']['max']))\n",
+    "        \n",
+    "    trace_plot1 = Scatter(\n",
+    "          x=clients,\n",
+    "          y=op_s, \n",
+    "          mode = 'lines+markers',\n",
+    "          name = 'WRITE',\n",
+    "          marker = dict(\n",
+    "            size = 10,\n",
+    "            color = 'rgb(91,79,224)')\n",
+    "        )\n",
+    "    \n",
+    "    trace_plot2 = Scatter(\n",
+    "          x=clients,\n",
+    "          y=op_s_r, \n",
+    "          mode = 'lines+markers',\n",
+    "          name = 'READ',\n",
+    "          marker = dict(\n",
+    "            size = 10,\n",
+    "            color = 'rgb(212,224,79)')\n",
+    "        )\n",
+    "        \n",
+    "    trace_plot3 = Scatter(\n",
+    "          x=clients,\n",
+    "          y=med, \n",
+    "          mode = 'lines+markers',\n",
+    "          name = 'WRITE-median', \n",
+    "          marker = dict(\n",
+    "            size = 10,\n",
+    "            color = 'rgb(91,79,224)')\n",
+    "        )\n",
+    "\n",
+    "    trace_plot4 = Scatter(\n",
+    "          x=clients,\n",
+    "          y=med_r, \n",
+    "          mode = 'lines+markers',\n",
+    "          name = 'READ-median', \n",
+    "          marker = dict(\n",
+    "            size = 10,\n",
+    "            color = 'rgb(212,224,79)')\n",
+    "        )\n",
+    "    trace_plot5 = Scatter(\n",
+    "          x=clients,\n",
+    "          y=p99, \n",
+    "          mode = 'lines+markers',\n",
+    "          name = 'WRITE-percentile 99', \n",
+    "          marker = dict(\n",
+    "            size = 10,\n",
+    "            color = 'rgb(222,44,118)')\n",
+    "        )\n",
+    "    trace_plot7 = Scatter(\n",
+    "          x=clients,\n",
+    "          y=max_lat, \n",
+    "          mode = 'lines+markers',\n",
+    "          name = 'WRITE-max', \n",
+    "          marker = dict(\n",
+    "            size = 10,\n",
+    "            color = 'rgb(29,113,204)')\n",
+    "        )\n",
+    "    trace_plot8 = Scatter(\n",
+    "          x=clients,\n",
+    "          y=p99_r, \n",
+    "          mode = 'lines+markers',\n",
+    "          name = 'READ-percentile 99', \n",
+    "          marker = dict(\n",
+    "            size = 10,\n",
+    "            color = 'rgb(255,151,5)')\n",
+    "        )\n",
+    "    trace_plot9 = Scatter(\n",
+    "          x=clients,\n",
+    "          y=max_lat_r, \n",
+    "          mode = 'lines+markers',\n",
+    "          name = 'READ-max', \n",
+    "          marker = dict(\n",
+    "            size = 10,\n",
+    "            color = 'rgb(36,218,242)')\n",
+    "        )\n",
+    "    \n",
+    "    traces_plot1.append(trace_plot1)\n",
+    "    traces_plot1.append(trace_plot2)\n",
+    "    traces_plot2.append(trace_plot3)\n",
+    "    traces_plot2.append(trace_plot4)\n",
+    "    traces_plot2.append(trace_plot5)\n",
+    "    traces_plot2.append(trace_plot7)\n",
+    "    traces_plot2.append(trace_plot8)\n",
+    "    traces_plot2.append(trace_plot9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Result Generation: operations per second vs. client count\n",
+    "\n",
+    "The following graph illustrates how, the number of operations per second changes while the number of clients increases "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%capture plot_med --no-stdout\n",
+    "\n",
+    "data = Data(traces_plot1)\n",
+    "# Edit the layout\n",
+    "layout = dict(title = 'op/s vs. # Clients',\n",
+    "              xaxis = dict(title = '# clients'),\n",
+    "              yaxis = dict(title = 'op/s'),\n",
+    "              )\n",
+    "\n",
+    "# Plot and embed in notebook\n",
+    "fig = dict(data=data, layout=layout)\n",
+    "offline.plot(fig, filename=ops_second_graph_filename + \"_offline\")\n",
+    "py.iplot(fig, filename = ops_second_graph_filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Result Generation: median latency vs. client count\n",
+    "\n",
+    "The following graph illustrates median latency in miliseconds for each operation during that run as the number of clients increases. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%capture plot_med --no-stdout\n",
+    "\n",
+    "data = Data(traces_plot2)\n",
+    "# Edit the layout\n",
+    "layout = dict(title = 'Latency vs. Client Count',\n",
+    "              xaxis = dict(title = '# Clients'),\n",
+    "              yaxis = dict(type='log', title = 'Latency [ms]'),\n",
+    "              )\n",
+    "\n",
+    "# Plot and embed in notebook\n",
+    "fig = dict(data=data, layout=layout)\n",
+    "offline.plot(fig, filename = median_latency_graph_filename + \"_offline\")\n",
+    "py.iplot(fig, filename = median_latency_graph_filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Overall, these benchmarks represent the **maximum throughput** of a 3 node cluster for the *default* model generated by the cassandra-stress tool. For accurate performance assessment of an application a range of parameters (including data model, queries, etc.) need to be adjusted. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/src/hCassandra_test.py
+++ b/src/hCassandra_test.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 __author__ = 'annyz'
 
 from sys import path
@@ -8,6 +9,12 @@ import sys
 import logging
 import math
 import ast
+import copy
+import json
+import threading
+import time
+import random
+import paramiko
 
 from datetime import datetime, timedelta
 from optparse import OptionParser
@@ -15,6 +22,7 @@ from pprint import pformat  # NOQA
 from hydra.lib import util
 from hydra.lib.h_analyser import HAnalyser
 from hydra.lib.hydrabase import HydraBase
+from cassandra.cluster import Cluster
 
 try:
     # Python 2.x
@@ -43,8 +51,8 @@ class RunTestCassandra(HydraBase):
         self.reset_all_app_stats(self.stress_client)
         # Signal message sending
         l.info("Sending signal to Cassandra Stress client to start sending all messages..")
-        # Force start-time for ALL clients +10 seconds from current time
-        start_time = datetime.now() + timedelta(seconds=10)
+        # Force start-time for ALL clients +60 seconds from current time
+        start_time = datetime.now() + timedelta(seconds=60)
         l.debug("Current Time: %s, Start Time: %s" % (datetime.now(), start_time))
         task_list = self.all_task_ids[self.stress_client]
         ha_list = []
@@ -57,8 +65,22 @@ class RunTestCassandra(HydraBase):
             ha_stress.start_test(start_time=start_time)
             ha_list.append(ha_stress)
         l.info('Waiting for test(s) to end...')
-        for ha_stress in ha_list:
+        if self.options.sim_failure:
+            l.debug("Simulate Cassandra Node Failure. Init.")
+            # Thread Event to indicate tests have been completed
+            tests_completed = threading.Event()
+            # Launch parallel Thread to simulate cassandra node failure.
+            l.debug("Launch separate thread to simulate node failure and rejoin.")
+            failure_thread = threading.Thread(target=simulate_node_failure, args=(self.options.cluster_ips.split(','),
+                                                                 self.options.test_duration, tests_completed))
+            failure_thread.start()
+        for idx, ha_stress in enumerate(ha_list):
+            l.debug('Waiting for task [%s] in [%s:%s] test to END. Iteration: %s' % (ha_stress.task_id, ha_stress.server_ip, ha_stress.port, idx))
             ha_stress.wait_for_testend()
+        if self.options.sim_failure:
+            l.debug("ALL tests are COMPLETED.")
+            tests_completed.set()
+        l.info('Fetch App Stats')
         self.fetch_app_stats(self.stress_client)
 
         return self.result_parser()
@@ -66,12 +88,77 @@ class RunTestCassandra(HydraBase):
     def run_test(self, first_run=True):
         # Get Mesos/Marathon Clients
         self.start_init()
+        # Reset (drop) Cassandra DB for cassandra-stress tool default 'keyspace1'
+        self.reset_db()
+        # Create Table(s) & Triggers for stress Test
+        # self.create_triggers()
         # Launch Cassandra Stress-Client(s)
         self.launch_stress_client()
         # Rerun the test
         res = self.rerun_test(self.options)
         # Return Test Results
         return res
+
+    def create_triggers(self):
+        try:
+            cluster_ips = self.options.cluster_ips.split(',')
+            cluster = Cluster(cluster_ips)
+            l.debug("Connecting to Cassandra Cluster: [%s]" % (cluster_ips))
+            session = cluster.connect()
+            l.info("Create keyspace [keyspace1]...")
+            # Create Keyspace
+            session.execute("CREATE KEYSPACE keyspace1 WITH replication = {'class': 'SimpleStrategy', "
+                            "'replication_factor': '1'}  AND durable_writes = true;")
+            l.info("Create tables [standard1] & [counter1]...")
+            table_create = "CREATE TABLE keyspace1.standard1 ( " \
+                           "key blob PRIMARY KEY," \
+                            "\"C0\" blob," \
+                            "\"C1\" blob," \
+                            "\"C2\" blob," \
+                            "\"C3\" blob," \
+                            "\"C3\" blob" \
+                            ") WITH COMPACT STORAGE" \
+                            "AND bloom_filter_fp_chance = 0.01" \
+                            "AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}" \
+                            "AND comment = ''" \
+                            "AND compaction = {'class': " \
+                            "'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'," \
+                            " 'min_threshold': '4'}" \
+                            "AND compression = {'enabled': 'false'}" \
+                            "AND crc_check_chance = 1.0" \
+                            "AND dclocal_read_repair_chance = 0.1" \
+                            "AND default_time_to_live = 0" \
+                            "AND gc_grace_seconds = 864000" \
+                            "AND max_index_interval = 2048" \
+                            "AND memtable_flush_period_in_ms = 0" \
+                            "AND min_index_interval = 128" \
+                            "AND read_repair_chance = 0.0" \
+                            "AND speculative_retry = '99PERCENTILE';"
+            l.info("Create standard1 Table")
+            # Create 'standard1' & 'counter1' default Tables
+            session.execute(table_create)
+            l.info('Succeeded to create keyspace1 and standard1 Table.')
+            # Create Trigger
+            trigger_jar = 'org.apache.cassandra.triggers.AuditTrigger'
+            trigger_cql = "CREATE TRIGGER pushTrigger ON keyspace1.standard1 USING " + trigger_jar
+            session.execute(trigger_cql)
+        except Exception as e:
+            l.error('FAILED to create trigger. Error: %s' % str(e))
+
+    def reset_db(self):
+        try:
+            ips = self.options.cluster_ips.split(',')
+            cluster = Cluster(ips)
+            l.debug("Connecting to Cassandra Cluster: [%s]" % (ips))
+            session = cluster.connect()
+            l.info("dropping [keyspace1] (default) keyspace...")
+            # session.execute("DROP KEYSPACE keyspace1")
+            # Instead of 'dropping' the complete keyspace, let's delete all rows in Tables, so they remain created for subsequent tests
+            session.execute("TRUNCATE keyspace1.counter1;")
+            session.execute("TRUNCATE keyspace1.standard1;")
+            l.info('Succeeded to delete DB.')
+        except Exception as e:
+            l.error('Failed to reset Cassandra DB. Error: %s' % str(e))
 
     def stop_and_delete_all_apps(self):
         self.delete_all_launched_apps()
@@ -89,14 +176,14 @@ class RunTestCassandra(HydraBase):
             'max': [],           # Maximum latency in miliseconds.
             'gc_num': 0,         # Number of garbage collections.
             'max_ms': [],        # Longest garbage collection in miliseconds.
-            'sum_ms': 0,         # Total of gargage collection in miliseconds.
+            'sum_ms': 0,         # Total of garbage collection in miliseconds.
             'sdv_ms': [],        # Standard deviation in miliseconds.
             'mb': 0,             # Size of the garbage collection in megabytes.
             'op_time': []        # Total Operation Time per client
         }
         cassandra_results = {
-            'write': dict(result),
-            'read': dict(result)
+            'write': copy.deepcopy(result),
+            'read': copy.deepcopy(result)
         }
         # Get stats for Cassandra Stress Client
         stats = self.get_app_stats(self.stress_client)
@@ -104,25 +191,28 @@ class RunTestCassandra(HydraBase):
         db_ops = ['write', 'read']
         for client in stats.keys():
             info = stats[client]
-            # l.info(" CLIENT = " + pformat(client) + " DATA = " + pformat(info))
             for db_op in db_ops:
                 if db_op in info:
-                    info[db_op] = ast.literal_eval(info[db_op])
-                    cassandra_results[db_op]['total ops'].append(info[db_op]['Total partitions'])
-                    cassandra_results[db_op]['op/s'].append(info[db_op]['op rate'])
-                    cassandra_results[db_op]['pk/s'].append(info[db_op]['partition rate'])
-                    cassandra_results[db_op]['.95'].append(info[db_op]['latency 95th percentile'])
-                    cassandra_results[db_op]['.99'].append(info[db_op]['latency 99th percentile'])
-                    cassandra_results[db_op]['gc_num'] += int(info[db_op]['total gc count'])
-                    cassandra_results[db_op]['sdv_ms'].append(info[db_op]['stdev gc time(ms)'])
-                    cassandra_results[db_op]['max'].append(info[db_op]['latency max'])
-                    cassandra_results[db_op]['med'].append(info[db_op]['latency median'])
-                    cassandra_results[db_op]['op_time'].append(info[db_op]['Total operation time'])
+                    try:
+                        info[db_op] = ast.literal_eval(info[db_op])
+                        cassandra_results[db_op]['total ops'].append(int(info[db_op]['Total partitions']))
+                        cassandra_results[db_op]['op/s'].append(int(info[db_op]['op rate']))
+                        cassandra_results[db_op]['pk/s'].append(int(info[db_op]['partition rate']))
+                        cassandra_results[db_op]['.95'].append(float(info[db_op]['latency 95th percentile']))
+                        cassandra_results[db_op]['.99'].append(float(info[db_op]['latency 99th percentile']))
+                        cassandra_results[db_op]['gc_num'] += int(info[db_op]['total gc count'])
+                        cassandra_results[db_op]['sdv_ms'].append(float(info[db_op]['stdev gc time(ms)']))
+                        cassandra_results[db_op]['max'].append(float(info[db_op]['latency max']))
+                        cassandra_results[db_op]['med'].append(float(info[db_op]['latency median']))
+                        cassandra_results[db_op]['op_time'].append((info[db_op]['Total operation time']).replace(' ', ''))
+                    except Exception as e:
+                        l.error("Failed to parse stats from Client: " + pformat(client) + " DATA = " + pformat(info[db_op]))
+                        l.error("ERROR: %s" % str(e))
 
         return cassandra_results
 
     def launch_stress_client(self):
-        max_threads_per_client = 10
+        max_threads_per_client = 20
         l.info("Launching the Cassandra Stress Client(s). Total clients = %s" % (self.options.total_client_count))
         # Determine number of threads per Cassandra Stress Client
         if self.options.total_client_count > max_threads_per_client:
@@ -130,39 +220,100 @@ class RunTestCassandra(HydraBase):
         else:
             threads_per_client = self.options.total_client_count
         l.debug("Number of Threads per Cassandra-Stress Client, set to: %s" % (threads_per_client))
-        self.create_binary_app(name=self.stress_client, app_script='./src/stress_client.py %s %s %s %s %s'
+        self.create_binary_app(name=self.stress_client, app_script='./src/stress_client.py %s %s %s %s %s %s'
                                                                    % (self.options.total_ops_count,
                                                                       threads_per_client,
                                                                       self.options.cluster_ips,
+                                                                      self.options.test_duration,
                                                                       self.options.cl,
                                                                       self.options.profile),
-                               cpus=0.01, mem=32, ports=[0])
+                               cpus=0.2, mem=600, ports=[0])
         if self.options.total_client_count > max_threads_per_client:
-            client_count = math.ceil(self.options.total_client_count / 10)
+            client_count = math.ceil(self.options.total_client_count / max_threads_per_client)
             l.info("Number of Cassandra-Stress Clients to launch = %s" % (client_count))
             self.scale_and_verify_app(self.stress_client, client_count)
-
 
     def delete_all_launched_apps(self):
         l.info("Deleting Stress Clients")
         self.delete_app(self.stress_client)
 
 
+def simulate_node_failure(node_ips, max_duration, tests_completed):
+    """
+        Simulate random cassandra node failure and 'rejoin' into cluster
+    """
+    run = True
+    l.info("START Cassandra Node Failure Simulation. Entering.")
+    while run:
+        # If stress-tests are still running continue with node failure simulation
+        if not tests_completed.isSet():
+            # Select 'random' node from Cassandra Cluster
+            node_ip = select_random_node(node_ips)
+            # Determine delay before stopping cassandra node (to simulate failure / node down)
+            duration_secs = max_duration*60
+            time_next_stop = random.randint(1, duration_secs/4)
+            l.debug("STOP programmed in %s seconds" % time_next_stop)
+            # Wait
+            time.sleep(time_next_stop)
+            ssh_fail = False
+            # Stop Cassandra Node (simulate failure / stop the service)
+            stop_cmd = "sudo service cassandra stop"
+            l.debug("STOP Cassandra Node: %s"%node_ip)
+            try:
+                ssh = paramiko.SSHClient()
+                ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+                ssh.connect(str(node_ip))
+                l.debug("[Simulate Cassandra Node Failure] Connected to host: %s" % node_ip)
+            except paramiko.AuthenticationException as e:
+                l.error("Authentication failed when connecting to %s. ERROR: %s" % (node_ip, e))
+                ssh_fail = True
+            except:
+                l.error("Could not SSH to %s, waiting for it to start" % node_ip)
+                ssh_fail = True
+            if not ssh_fail:
+                # Send the command to STOP cassandra node
+                ssh.exec_command(stop_cmd)
+                # Determine delay before starting cassandra node (to simulate rejoin to the cluster)
+                time_next_rejoin = random.randint(1, duration_secs/4)
+                l.debug("START programmed in %s seconds" % time_next_rejoin)
+                time.sleep(time_next_rejoin)
+                # Start Cassandra Node (simulate rejoin / start the service)
+                start_cmd = "sudo service cassandra start"
+                l.debug("START Cassandra Node: %s"%node_ip)
+                # Send the command (non-blocking)
+                ssh.exec_command(start_cmd)
+                # Disconnect from the host
+                l.debug("Closing SSH connection to host: %s" % node_ip)
+                ssh.close()
+                run=False
+        else:
+            # Tests Complete has been signaled
+            run=False
+            l.info("END node failure simulation. Exiting.")
+
+def select_random_node(cluster_ips):
+    """
+        Select a random cassandra node from a list of IPs
+    """
+    return random.choice(cluster_ips)
+
 class RunTest(object):
     def __init__(self, argv):
         usage = ('python %prog --test_duration=<time to run test> --total_ops_count=<Total Operations>'
                  '--total_client_count=<Total clients to launch> --cluster_ips=<cassandra node list ips>'
                  '--consistency_level=<cassandra consistency level> --profile=<yaml profile>'
-                 '--config_file=<path_to_config_file>')
+                 '--config_file=<path_to_config_file> --sim_failure=<simulate node failure>')
         parser = OptionParser(description='cassandra scale test master',
                               version="0.1", usage=usage)
-        parser.add_option("--test_duration", dest='test_duration', type='float', default=10)
+        parser.add_option("--test_duration", dest='test_duration', type='int', default=5)
         parser.add_option("--total_ops_count", dest='total_ops_count', type='int', default=1000000)
         parser.add_option("--total_client_count", dest='total_client_count', type='int', default=20)
         parser.add_option("--cluster_ips", dest='cluster_ips', type='string', default='127.0.0.1')
         parser.add_option("--consistency_level", dest='cl', type='string', default='LOCAL_ONE')
         parser.add_option("--profile", dest='profile', type='string', default='hydra_profile.yaml')
         parser.add_option("--config_file", dest='config_file', type='string', default='hydra.ini')
+        parser.add_option("--sim_failure", dest='sim_failure', action="store_true", default=False)
+
 
         (options, args) = parser.parse_args()
         # Check NO list of positional arguments leftover after parsing options
@@ -176,7 +327,8 @@ class RunTest(object):
         res = r.run_test()
         r.delete_all_launched_apps()
         # Cassandra-Stress Test Results
-        l.info("Cassandra Stress Results: \n%s" % pformat(res))
+        result_json = json.dumps(res)
+        print("Cassandra Stress Results: \n%s" % pformat(result_json))
         r.stop_appserver()
 
 if __name__ == "__main__":

--- a/src/stress_client.py
+++ b/src/stress_client.py
@@ -1,4 +1,9 @@
+#!/usr/bin/env python
 __author__ = 'annyz'
+
+from sys import path
+# Append 'hydra' directory to Python path
+path.append("hydra/src/main/python")
 
 import logging
 import os
@@ -39,11 +44,15 @@ class HDCStressRepSrv(HDaemonRepSrv):
         """
         l.info('Scheduling Test to start %s.' % (start_time))
         start_time = datetime.strptime(start_time, "%Y-%m-%d %H:%M:%S.%f")
-        test_scheduler = BackgroundScheduler()
-        test_scheduler.add_job(lambda: time_to_start(self.run_data), next_run_time=start_time)
-        test_scheduler.start()
         self.run_data['test_status'] = 'running'
         self.run_data['stats']['msg_cnt'] = self.stress_metrics['ops_count']
+        # If time to start has passed, start immediately
+        if start_time < datetime.now():
+            time_to_start(self.run_data)
+        else:
+            test_scheduler = BackgroundScheduler()
+            test_scheduler.add_job(lambda: time_to_start(self.run_data), next_run_time=start_time)
+            test_scheduler.start()
         # Report Status
         return ('ok', None)
 
@@ -77,16 +86,44 @@ class HDCStressRepSrv(HDaemonRepSrv):
 
 def time_to_start(run_data):
     l.info('Starting Cassandra Stress Test at: %s' % (datetime.utcnow()))
-    process = psutil.Process()
     # Initialize test data collection
     run_data['start'] = True
-    run_data['stats']['write'] = {'net:start': json.dumps(psutil.net_io_counters()),
-                                  'cpu:start': json.dumps(process.cpu_times()),
-                                  'mem:start': json.dumps(process.memory_info()),
-                                  'time:start': json.dumps(time.time())
-                                  }
-    run_data['stats']['read'] = {}
     return
+
+
+def parse_results(stdout, run_data):
+    try:
+        l.info('Start parsing cassandra-stress output.')
+        index_start = stdout.find('op rate')
+        index_end = stdout.find('END')
+        if (index_start and index_end) != -1:
+            results = stdout[index_start:index_end]
+            # find 'matches' of the type att_name:value
+            matches = re.findall(r'.+\:{1}.+', results)
+            # partition each match at ':'
+            matches = [m.split(':', 1) for m in matches]
+            # Remove extra whitespaces
+            for pair in matches:
+                for idx, m in enumerate(pair):
+                    pair[idx] = re.sub(r'\s{2,}', '', m)
+            # Build dictionary of results
+            result_dict = dict(matches)
+            # Remove [] in results
+            for key, value in result_dict.iteritems():
+                result_dict[key] = re.sub(r'\[{1}.{1,}\]{1}', '', value)
+            run_data.update(result_dict)
+    except Exception, e:
+        l.error("ERROR while parsing Cassandra-Stress OUTPUT. Error: %s" % str(e))
+
+
+def check_user_queries(data_profile):
+    """
+    Check if 'user' queries are defined in YAML Profile.
+    :param data_profile: .yaml profile
+    :return: True if custom user queries are defined in profile, otherwise, False
+    """
+    # TODO: Analyze 'profile' and set 'user_queries'
+    return False
 
 
 def run(argv):
@@ -97,13 +134,14 @@ def run(argv):
     user_queries = False
 
     # Parse Inputs
-    if len(argv) > 5:
+    if len(argv) >= 6:
         ops_count = argv[1]             # number of Operations (e.g., n=1000000 insert/read one million rows)
         client_count = argv[2]          # client count (client threads)
         cluster_ips = argv[3]           # C*-Cluster IPs
-        # consistency_level = argv[4]     # consistency level, default='LOCAL_ONE'
-    if len(argv) > 6:
-        stress_profile = argv[4]        # (optional) .yaml profile (defines data model & queries)
+        duration = argv[4]
+        consistency_level = argv[5]     # consistency level, default='LOCAL_ONE'
+    if len(argv) >= 7:
+        stress_profile = argv[6]        # (optional) .yaml profile (defines data model & queries)
         user_queries = check_user_queries(stress_profile)
 
     # Initialize 'run_data'
@@ -127,42 +165,57 @@ def run(argv):
             continue
         l.info("START SIGNAL received. Cassandra Client initiating Stress Test...")
 
+        process = psutil.Process()
+        hd.run_data['stats']['write'] = {'net:start': json.dumps(psutil.net_io_counters()),
+                                         'cpu:start': json.dumps(process.cpu_times()),
+                                         'mem:start': json.dumps(process.memory_info()),
+                                         'time:start': json.dumps(time.time())
+                                        }
+
         # The cluster must be first populated by a 'write' test
-        w_start_time = time.time()              # write 'start' time
-        base_cmd = 'cassandra-stress %s n=%s -rate threads=%s -node %s'
-        write_cmd = base_cmd % ('write', ops_count, client_count,
+        base_cmd = 'cassandra-stress %s cl=%s duration=%sm -rate threads=%s -node %s -schema "replication(factor=2)"'
+        write_cmd = base_cmd % ('write', 'QUORUM', duration, client_count,
                                 cluster_ips)
 
-        # Initiate Subprocess Call (WRITE OPERATION)
-        l.info('Execute command: %s' % (write_cmd))
-        stress_process = subprocess.Popen(write_cmd, stdout=subprocess.PIPE,
-                                          stderr=subprocess.PIPE, shell=True, preexec_fn=os.setsid)
-        stdout_w, stderr_w = stress_process.communicate()
-        cmd_status_w = stress_process.returncode
-        if cmd_status_w != 0:
-            l.error('Error while running Cassandra-Stress WRITE Operation. Return Code: %s' % (cmd_status_w))
-        l.debug('Output of Cassandra-Stress Test WRITE operation: %s' % (stdout_w))
-        l.debug('stderr of Cassandra-Stress Test WRITE operation: %s' % (stderr_w))
+        retries = 20
+        while retries > 0:
+            # Initiate Subprocess Call (WRITE OPERATION)
+            l.info('Execute command: %s' % (write_cmd))
+            stress_process = subprocess.Popen(write_cmd, stdout=subprocess.PIPE,
+                                              stderr=subprocess.PIPE, shell=True, preexec_fn=os.setsid)
+            stdout_w, stderr_w = stress_process.communicate()
+
+            cmd_status_w = stress_process.returncode
+            if cmd_status_w != 0:
+                l.error('Error while running Cassandra-Stress WRITE Operation. Return Code: %s' % (cmd_status_w))
+            l.debug('Output of Cassandra-Stress Test WRITE operation: %s' % (stdout_w))
+            l.debug('stderr of Cassandra-Stress Test WRITE operation: %s' % (stderr_w))
+
+            if 'NoHostAvailableException' in stderr_w:
+                retries = retries - 1
+                continue
+            else:
+                break
+
 
         # Write stats to 'run_data'
-        hd.run_data['stats']['write']['time:start'] = json.dumps(w_start_time)
         hd.run_data['stats']['write']['time:end'] = json.dumps(time.time())
-        parse_results(stdout_w, hd.run_data['stats']['write'])
-        l.debug("Updated RUN_DATA: \n%s" % pformat(hd.run_data))
-        process = psutil.Process()
         hd.run_data['stats']['write']['net:end'] = json.dumps(psutil.net_io_counters())
         hd.run_data['stats']['write']['cpu:end'] = json.dumps(process.cpu_times())
         hd.run_data['stats']['write']['mem:end'] = json.dumps(process.memory_info())
+        parse_results(stdout_w, hd.run_data['stats']['write'])
+        l.debug("Updated RUN_DATA: \n%s" % pformat(hd.run_data))
 
         # Initiate Subprocess Call (READ/QUERY OPERATION)
         if not user_queries:
-            query_cmd = base_cmd % ('read', ops_count, client_count,
+            query_cmd = base_cmd % ('read', 'ONE', duration, client_count,
                                     cluster_ips)
         else:
-            query_cmd = base_cmd % ('user', ops_count, client_count,
+            query_cmd = base_cmd % ('user', 'ONE', duration, client_count,
                                     cluster_ips)
             query_cmd += 'profile=%s' % (stress_profile)
 
+        hd.run_data['stats']['read'] = {}
         q_start_time = time.time()
         l.debug('Execute command: %s' % (query_cmd))
         stress_process = subprocess.Popen(query_cmd, stdout=subprocess.PIPE,
@@ -177,10 +230,10 @@ def run(argv):
         # Write stats to 'run_data'
         hd.run_data['stats']['read']['time:start'] = json.dumps(q_start_time)
         hd.run_data['stats']['read']['time:end'] = json.dumps(time.time())
-        parse_results(stdout_q, hd.run_data['stats']['read'])
         hd.run_data['stats']['read']['net:end'] = json.dumps(psutil.net_io_counters())
         hd.run_data['stats']['read']['cpu:end'] = json.dumps(process.cpu_times())
         hd.run_data['stats']['read']['mem:end'] = json.dumps(process.memory_info())
+        parse_results(stdout_q, hd.run_data['stats']['read'])
         hd.run_data['test_status'] = 'stopping'
         hd.run_data['start'] = False
         hd.run_data['msg_cnt'] = ops_count
@@ -189,35 +242,3 @@ def run(argv):
 
 if __name__ == "__main__":
     run(sys.argv)
-
-
-def parse_results(stdout, run_data):
-    try:
-        l.info('Start parsing cassandra-stress output.')
-        index_start = stdout.find('op rate')
-        index_end = stdout.find('END')
-        if (index_start and index_end) != -1:
-            results = stdout[index_start:index_end]
-            # find 'matches' of the type att_name:value
-            matches = re.findall(r'.+\:{1}.+', results)
-            # partition each match at ':'
-            matches = [m.split(':', 1) for m in matches]
-            # Remove extra whitespaces
-            for pair in matches:
-                for idx, m in enumerate(pair):
-                    pair[idx] = re.sub(r'\s{2,}', '', m)
-            # Build dictionary of results
-            result_dict = dict(matches)
-            run_data.update(result_dict)
-    except Exception, e:
-        l.error("ERROR while parsing Cassandra-Stress OUTPUT. Error: %s" % str(e))
-
-
-def check_user_queries(data_profile):
-    """
-    Check if 'user' queries are defined in YAML Profile.
-    :param data_profile: .yaml profile
-    :return: True if custom user queries are defined in profile, otherwise, False
-    """
-    # TODO: Analyze 'profile' and set 'user_queries'
-    return False


### PR DESCRIPTION
- Instead of deleting the key space between tests, we are only deleting all rows from default tables in between each test iteration. 
- Throughout experimentation we determined the most suitable duration of each test (regards to the number of clients) to avoid stress-tool issue with read operations. 
- Changed CL = ONE to CL= QUORUM for read operations. 